### PR TITLE
Ruby 3.x compatibility: add gemspec ruby version constraint

### DIFF
--- a/workarea-product_badges.gemspec
+++ b/workarea-product_badges.gemspec
@@ -15,5 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
+  s.required_ruby_version = ['>= 2.7', '< 3.5']
+
   s.add_dependency "workarea", "~> 3.x", ">= 3.4.x"
 end


### PR DESCRIPTION
## Summary

Modernizes the plugin for Ruby 3.2+ compatibility.

### Changes
- Set `required_ruby_version` to `['>= 2.7', '< 3.5']` in gemspec

### Testing
- No deprecated API patterns found in this plugin
- Backward compatible with Ruby 2.7+

Client impact: None — backward compatible

Closes workarea-commerce/workarea#677